### PR TITLE
fixed: FORUMS->ORDER GROUPS AND FORUMS

### DIFF
--- a/admin/panel-forums/support/spa-forums-save.php
+++ b/admin/panel-forums/support/spa-forums-save.php
@@ -1153,7 +1153,8 @@ function spa_save_forums_order() {
 	check_admin_referer('forum-adminform_forumorder', 'forum-adminform_forumorder');
 
 	# get the sorted lst
-	parse_str(SP()->filters->str($_POST['spForumsOrder']), $list);
+	// parse_str(SP()->filters->str($_POST['spForumsOrder']), $list);
+        parse_str(filter_input(INPUT_POST, 'spForumsOrder', FILTER_SANITIZE_URL), $list);
 
 	# make sure we have groups
 	if (empty($list['group'])) return SP()->primitives->admin_text('Unable to save group/forum ordering');


### PR DESCRIPTION
If you go to FORUMS->ORDER GROUPS AND FORUMS, you can drag-and-drop to reorder the forums but for some reason when you save, the forums return to their original position.