### PR TITLE
fixed: Attempting to edit css for themes does not work

### DIFF
--- a/admin/panel-components/support/spa-components-save.php
+++ b/admin/panel-components/support/spa-components-save.php
@@ -19,7 +19,7 @@ function spa_save_smileys_data() {
 	$sfsmileys = array();
 	$path = SP_STORE_DIR.'/'.SP()->plugin->storage['smileys'].'/';
 
-	$allSmileys = array_map('SP()->filters->str', $_POST['smname']);
+	$allSmileys = array_map(array(SP()->filters, 'str'), $_POST['smname']);
 	$numSmileys = SP()->filters->integer($_POST['smiley-count']);
 
 	if ($numSmileys) {

--- a/admin/panel-themes/forms/spa-themes-editor-form.php
+++ b/admin/panel-themes/forms/spa-themes-editor-form.php
@@ -86,7 +86,7 @@ function spa_themes_editor_form() {
 		foreach ($stylesheets as $style) {
 			echo '<li>';
 			if ($style == $filename) echo '<span class="highlight">';
-			echo '<a href="'.admin_url('admin.php?page'.SP_FOLDER_NAME.'/admin/panel-themes/spa-themes.php&amp;tab=editor&amp;file='.esc_attr($style).'&amp;type=style').'">'.$style.'</a>';
+			echo '<a href="'.admin_url('admin.php?page='.SP_FOLDER_NAME.'/admin/panel-themes/spa-themes.php&amp;tab=editor&amp;file='.esc_attr($style).'&amp;type=style').'">'.$style.'</a>';
 			if ($style == $filename) echo '</span>';
 			echo '</li>';
 		}


### PR DESCRIPTION
Bug Fix: Attempting to edit css for themes does not work
If you go to FORUM->THEMES->THEME EDITOR and try to edit a css file (choosing from the bottom right hand side), you’ll get a blank screen.