### PR TITLE
done: Use Code Mirror for our CSS Editors

### DIFF
--- a/admin/library/spa-tab-support.php
+++ b/admin/library/spa-tab-support.php
@@ -8,6 +8,14 @@ $Rev: 15187 $
 
 if (preg_match('#'.basename(__FILE__).'#', $_SERVER['PHP_SELF'])) die('Access denied - you cannot directly call this file');
 
+// Load style and scripts for WP Code Editor 
+wp_enqueue_style( 'code-editor' );
+wp_enqueue_script( 'code-editor' );
+wp_enqueue_script( 'htmlhint' );
+wp_enqueue_script( 'csslint' );
+wp_enqueue_script( 'jshint' );
+
+
 # == PAINT ROUTINES
 
 # ------------------------------------------------------------------
@@ -361,6 +369,83 @@ function spa_cache_ajax_editor_settings( $mceInit, $editor_id ) {
 	return $mceInit;
 }
 
+/**
+ * Print thin code css editor
+ * 
+ * @param string $label
+ * @param string $name
+ * @param string $value
+ * @param string $submessage [optional]
+ * @param int $rows [optional]
+ */
+function spa_paint_css_editor($label, $name, $value, $submessage='', $rows=10) {
+    spa_paint_code_editor('text/css', $label, $name, $value, $submessage, $rows);
+}
+
+/**
+ * Print thin code javascript editor
+ * 
+ * @param string $label
+ * @param string $name
+ * @param string $value
+ * @param string $submessage [optional]
+ * @param int $rows [optional]
+ */
+function spa_paint_js_editor($label, $name, $value, $submessage='', $rows=10) {
+    spa_paint_code_editor('text/javascript', $label, $name, $value, $submessage, $rows);
+}
+
+/**
+ * Print thin code html editor
+ * 
+ * @param string $label
+ * @param string $name
+ * @param string $value
+ * @param string $submessage [optional]
+ * @param int $rows [optional]
+ */
+function spa_paint_html_editor($label, $name, $value, $submessage='', $rows=10) {
+    spa_paint_code_editor('text/html', $label, $name, $value, $submessage, $rows);
+}
+
+/**
+ * Print thin WP Code Editor
+ * 
+ * @global int $tab
+ * 
+ * @param string $type CodeMirror type: "text/html", "text/css", "text/javascript"
+ * @param string $label
+ * @param string $name
+ * @param string $value
+ * @param string $submessage [optional]
+ * @param int $rows [optional]
+ */
+function spa_paint_code_editor($type, $label, $name, $value, $submessage='', $rows=10) {
+    global $tab;
+    echo "<div class='sp-form-row'>\n";
+    echo "<div class='wp-core-ui sflabel sp-label'>\n";
+    if(mb_strlen($label)) {
+        echo "$label:";
+    }
+    if (mb_strlen($submessage)) {
+        echo "<small><br /><strong>$submessage</strong><br /><br /></small>\n";
+    }
+    $id = sprintf("sp-%s-editor-%d", str_replace('/', '-', $type), $tab);
+    echo '</div>';
+    echo '<div class="clearboth"></div>';
+    echo "<textarea id=\"$id\" class=\"wp-core-ui sp-textarea\" rows=\"{$rows}\" name=\"{$name}\" tabindex=\"{$tab}\">{$value}</textarea>";
+    if(floatval(get_bloginfo('version')) >= 4.9) {
+        echo "<script>";
+        echo sprintf( "jQuery( function() { 
+                        var instance = wp.codeEditor.initialize( '{$id}', %s );
+                        instance.codemirror.on('blur', function() {instance.codemirror.save();});                         
+                    });", wp_json_encode(wp_enqueue_code_editor(array('type' => $type))) ) ;
+        echo "</script>";
+    }
+    echo '<div class="clearboth"></div>';
+    echo '</div>';
+    $tab++;
+}
 
 
 function spa_paint_checkbox($label, $name, $value, $disabled=false, $large=false, $displayhelp=true, $msg='', $indent=false) {

--- a/admin/library/spa-tab-support.php
+++ b/admin/library/spa-tab-support.php
@@ -8,12 +8,15 @@ $Rev: 15187 $
 
 if (preg_match('#'.basename(__FILE__).'#', $_SERVER['PHP_SELF'])) die('Access denied - you cannot directly call this file');
 
+
 // Load style and scripts for WP Code Editor 
-wp_enqueue_style( 'code-editor' );
-wp_enqueue_script( 'code-editor' );
-wp_enqueue_script( 'htmlhint' );
-wp_enqueue_script( 'csslint' );
-wp_enqueue_script( 'jshint' );
+if(floatval(get_bloginfo('version')) >= 4.9) {
+    wp_enqueue_style( 'code-editor' );
+    wp_enqueue_script( 'code-editor' );
+    wp_enqueue_script( 'htmlhint' );
+    wp_enqueue_script( 'csslint' );
+    wp_enqueue_script( 'jshint' );
+}
 
 
 # == PAINT ROUTINES

--- a/admin/panel-themes/forms/spa-themes-css-form.php
+++ b/admin/panel-themes/forms/spa-themes-css-form.php
@@ -35,7 +35,7 @@ function spa_themes_css_form() {
 	spa_paint_open_fieldset(SP()->primitives->admin_text('CSS Editor'), true, 'css-editor');
 
 	echo '<div>';
-	echo '<textarea rows="25" name="spnewcontent" id="spnewcontent" tabindex="1">'.$css.'</textarea>';
+        spa_paint_css_editor("", "spnewcontent", $css, "", 25);
 	echo '<input type="hidden" name="metaId" value="'.$id.'" />';
 	echo '</div>';
 


### PR DESCRIPTION
WordPress 4.9 and later introduced codemirror scripts for css editors.  So we can now integrate this into Simple:Press.  However, we only want to do this if the version that the user is running on is WordPress 4.9 or later.
The CSS editor is located under FORUM->THEMES->CUSTOM CSS.
Right now this editor is just a text box, likely being rendered via an spa_paint_text_area function.  We should create a new spa_paint_xxx function called spa_paint_css_editor.   This function will paint an editor that uses the core wordpress code-mirror scripts for css validation and color coding if running on WP 4.9 or later.  If running on a version of WP that is earlier than 4.9, it will just render a text box just like its doing now.
+ Bonus: spa_paint_js_editor() and spa_paint_html_editor()