### PR TITLE
Fix RSS CDATA double-escaping

### DIFF
--- a/forum/feeds/sp-feeds.php
+++ b/forum/feeds/sp-feeds.php
@@ -27,7 +27,7 @@ if (isset($rssopt['sfrssfeedkey']) && $rssopt['sfrssfeedkey']) {
 
 # = Support Functions ===========================
 function sp_rss_filter($text) {
-	echo esc_html(convert_chars(ent2ncr($text)));
+        echo wp_kses_post(convert_chars(ent2ncr($text)));
 }
 
 function sp_rss_excerpt($text) {


### PR DESCRIPTION
**Summary**
This PR fixes a double-escaping issue in RSS feeds by replacing `esc_html()` with `wp_kses_post()` in `sp_rss_filter()`. Allowed HTML tags and attributes are preserved, and output remains safely sanitized.

---

**Background**
When RSS content is wrapped in `<![CDATA[ … ]]>`, using `esc_html()` causes HTML entities to be escaped twice, resulting in broken markup or literal entity strings in feed readers.

---

**Changes**

```diff
 function sp_rss_filter($text) {
-    echo esc_html(convert_chars(ent2ncr($text)));
+    echo wp_kses_post(convert_chars(ent2ncr($text)));
 }
```

* **Before:** All HTML was converted to entities, then escaped again by `esc_html()`.
* **After:** `wp_kses_post()` sanitizes but allows standard HTML tags (e.g., `<a>`, `<strong>`, `<em>`), preventing double-escaping inside CDATA.
