### PR TITLE
Fix: Null reference warnings and database error in SimplePress

### DIFF
--- a/forum/content/sp-profile-view-functions.php
+++ b/forum/content/sp-profile-view-functions.php
@@ -329,7 +329,7 @@ function sp_ProfileShowFirstName($args = '', $label = '') {
 
     // If option to hide firstname and lastname is set, do not return any data
     $profileOptions = SP()->options->get('sfprofile');
-    if ($profileOptions['hideuserinfo']) {
+    if (!empty($profileOptions['hideuserinfo'])) {
         return;
     }
 
@@ -392,7 +392,7 @@ function sp_ProfileShowLastName($args = '', $label = '') {
 
     // If option to hide firstname and lastname is set, do not return any data
     $profileOptions = SP()->options->get('sfprofile');
-    if ($profileOptions['hideuserinfo']) {
+    if (!empty($profileOptions['hideuserinfo'])) {
         return;
     }
 
@@ -1738,7 +1738,7 @@ function sp_ProfileShowEmail($args = '', $label = '') {
 
     // If option to hide firstname and lastname is set, do not return any data
     $profileOptions = SP()->options->get('sfprofile');
-    if ($profileOptions['hideuserinfo']) {
+    if (!empty($profileOptions['hideuserinfo'])) {
         return;
     }
 

--- a/forum/database/sp-db-management.php
+++ b/forum/database/sp-db-management.php
@@ -1271,17 +1271,17 @@ function sp_transient_cleanup() {
     $time = time();
 
     // Prepare SQL for selecting expired transients
+	$tname = $wpdb->esc_sql( SP_PREFIX . 'options' );
     $records = $wpdb->get_results(
         $wpdb->prepare(
-            'SELECT * FROM %s
+            "SELECT * FROM `{$tname}`
                 WHERE (
                     (option_name LIKE %s AND option_value < %d) OR
                     (option_name LIKE %s AND option_value < %d) OR
                     (option_name LIKE %s AND option_value < %d) OR
                     (option_name LIKE %s AND option_value < %d) OR
                     (option_name LIKE %s AND option_value < %d)
-                )',
-            SP_PREFIX . "options",
+                )",
             '_transient_timeout_%url', $time,
             '_transient_timeout_%bookmark', $time,
             '_transient_timeout_%post', $time,

--- a/sp-startup/admin/spa-admin-support-functions.php
+++ b/sp-startup/admin/spa-admin-support-functions.php
@@ -852,7 +852,7 @@ function spa_plugin_addon_dashboard_update()
 		
 		}else{
 
-			if ($xml) {
+			if ($xml && !empty($xml->plugins->plugin)) {
 					
 				foreach ($xml->plugins->plugin as $latest) {
 					
@@ -1068,7 +1068,7 @@ function spa_check_plugin_addon_update() {
 		
 		}else{
 
-			if ($xml) {
+			if ($xml && !empty($xml->plugins->plugin)) {
 					
 				foreach ($xml->plugins->plugin as $latest) {
 					

--- a/sp-startup/core/sp-core-support-functions.php
+++ b/sp-startup/core/sp-core-support-functions.php
@@ -249,7 +249,7 @@ function sp_load_version_xml($showError = true, $usecache = true) {
  */
 function sp_check_for_updates() {
 	$xml = sp_load_version_xml();
-	if ($xml) {
+	if ($xml && !empty($xml->plugins->plugin)) {
 		# make sure SP is installed
 		$installed_build = SP()->options->get('sfbuild');
 		if (empty($installed_build)) return;


### PR DESCRIPTION
Fixed a couple of places in the code that are missing null checks, causing null reference warnings in error logs.

Also fixed a database query that does not run because it uses ' to name tables instead of `.